### PR TITLE
Fixes to issues found while packaging tappy for Debian.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,8 +234,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'tappy', u'tappy Documentation',
-     [u'Matt Layman'], 1)
+    ('tappy.1', 'tappy', u'a tap consumer for python',
+     [], 1)
 ]
 
 # If true, show URL addresses after external links.

--- a/docs/tappy.1.rst
+++ b/docs/tappy.1.rst
@@ -25,7 +25,7 @@ tools, you may use tappy to *replay* tests from .tap files,
 without having to actually run the tests again (which is much
 faster).
 
-It is also a example of how to use the tap consumer API
+It is also an example of how to use the tap consumer API
 provided by the :py:mod:`tap` module.
 
 .. warning::
@@ -47,16 +47,16 @@ Aliases
 -------
 
 When installed from a Debian package, the tappy command can be
-ran against a specific python interpreter. Debian's current
-policy with respect python is to favor Python 3. Thus, if you
-install the :file:`python3-tappy` package, :program:`tappy`
+run against a specific python interpreter. Debian's current
+policy with respect to Python is to favor Python 3. Thus, if
+you install the :file:`python3-tappy` package, :program:`tappy`
 will run with Python 3. You can use the
 :manpage:`update-alternatives(1)` command to change that
-behaviour and favor the version running against the Python 2.
+behaviour and favor the version running against Python 2.
 
 Alternatively you can select the interpreter, by explicitly
 choosing either of the :program:`python-tappy` and
-:program:`python3-tappy` command.
+:program:`python3-tappy` commands.
 
 :manpage:`tappy(1)`, :manpage:`python-tappy(1)`, :manpage:`python3-tappy(1)`
 

--- a/docs/tappy.1.rst
+++ b/docs/tappy.1.rst
@@ -3,10 +3,11 @@
 tappy manual page
 =================
 
+
 Synopsis
 --------
 
-**tappy** [*options*] <*pathname*> [*pathname* ...]
+**tappy** [*options*] <*pathname*> [<*pathname*> ...]
 
 
 Description
@@ -35,30 +36,13 @@ provided by the :py:mod:`tap` module.
    and failure messages (e.g. stack traces, ...) that are not
    recorded in tap files.
 
+
 Options
 -------
 
 -h, --help     show a short description and option list
                and exit.
 -v, --verbose  produce verbose output
-
-
-Aliases
--------
-
-When installed from a Debian package, the tappy command can be
-run against a specific python interpreter. Debian's current
-policy with respect to Python is to favor Python 3. Thus, if
-you install the :file:`python3-tappy` package, :program:`tappy`
-will run with Python 3. You can use the
-:manpage:`update-alternatives(1)` command to change that
-behaviour and favor the version running against Python 2.
-
-Alternatively you can select the interpreter, by explicitly
-choosing either of the :program:`python-tappy` and
-:program:`python3-tappy` commands.
-
-:manpage:`tappy(1)`, :manpage:`python-tappy(1)`, :manpage:`python3-tappy(1)`
 
 
 Author

--- a/docs/tappy.1.rst
+++ b/docs/tappy.1.rst
@@ -1,0 +1,71 @@
+:orphan:
+
+tappy manual page
+=================
+
+Synopsis
+--------
+
+**tappy** [*options*] <*pathname*> [*pathname* ...]
+
+
+Description
+-----------
+
+The :program:`tappy` command consumes the list of tap files
+given as *pathname* s and produces an output similar to what
+the regular text test-runner from python's :py:mod:`unittest`
+module would. If *pathname* points to a directory,
+:program:`tappy` will look in that directory of ``*.tap``
+files to consume.
+
+If you have a tool that consumes the `unittest` regular output,
+but wish to use the TAP protocol to better integrate with other
+tools, you may use tappy to *replay* tests from .tap files,
+without having to actually run the tests again (which is much
+faster).
+
+It is also a example of how to use the tap consumer API
+provided by the :py:mod:`tap` module.
+
+.. warning::
+
+   :program:`tappy`'s output will differ from the standard
+   :py:mod:`unittest` output. Indeed it cannot reproduce error
+   and failure messages (e.g. stack traces, ...) that are not
+   recorded in tap files.
+
+Options
+-------
+
+-h, --help     show a short description and option list
+               and exit.
+-v, --verbose  produce verbose output
+
+
+Aliases
+-------
+
+When installed from a Debian package, the tappy command can be
+ran against a specific python interpreter. Debian's current
+policy with respect python is to favor Python 3. Thus, if you
+install the :file:`python3-tappy` package, :program:`tappy`
+will run with Python 3. You can use the
+:manpage:`update-alternatives(1)` command to change that
+behaviour and favor the version running against the Python 2.
+
+Alternatively you can select the interpreter, by explicitly
+choosing either of the :program:`python-tappy` and
+:program:`python3-tappy` command.
+
+:manpage:`tappy(1)`, :manpage:`python-tappy(1)`, :manpage:`python3-tappy(1)`
+
+
+Author
+------
+
+The :program:`tappy` and the :py:mod:`tap` modules were written
+by Matt LAYMAN (https://github.com/mblayman/tappy).
+
+This manual page was written Nicolas CANIART, for the Debian project.
+

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,20 @@ import sys
 
 __version__ = '1.3'
 
+
+def install_requirements():
+    requirements = [
+        'nose',
+        'Pygments==2.0.1',
+        ]
+    if (2, 7, 0) > sys.version_info:
+        requirements.append('argparse')
+
+    if (3, 3, 0) > sys.version_info:
+        requirements.append('mock')
+
+    return requirements
+
 # The docs import setup.py for the version so only call setup when not behaving
 # as a module.
 if __name__ == '__main__':
@@ -22,13 +36,7 @@ if __name__ == '__main__':
 
     long_description = __doc__ + '\n\n' + releases
 
-    install_requires = [
-        'argparse',  # For Python 2.6 support
-        'mock',
-        'nose',
-        'Pygments==2.0.1',
-    ]
-
+    install_requires = install_requirements()
     # Add some developer tools.
     if 'develop' in sys.argv:
         install_requires.extend([

--- a/tap/tests/test_adapter.py
+++ b/tap/tests/test_adapter.py
@@ -2,7 +2,10 @@
 
 import sys
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from tap.adapter import Adapter
 from tap.tests import TestCase


### PR DESCRIPTION
Hi !

  I packaged tappy in the Debian format. For myself and started the process to have it included into the
distribution (which may or may not succeed eventually, I am not a DD). In the process I found the following issues:

  - your ``setup.py`` cannot produce binary distribution with Python 3.4 (and probably earlier version but 
    Debian no longer support them). The reason is that you depend on packages that are not available
    for Python 3 (``argparse``). I added a small function in ``setup.py`` to deal with that. While at it, I also
    removed the dependency on ``mock`` for Python versions above 3.3.

- Debian's policy requires that any command/script accessible through the system PATH be accompanied
  with its manpage. So I added one, generated with sphinx (no additional tool required).

Regards,
Nicolas.