### PR TITLE
Get the class name when the test is a ContextSuite.

### DIFF
--- a/tap/plugin.py
+++ b/tap/plugin.py
@@ -11,6 +11,7 @@ except ImportError:
         pass
 
 from nose.plugins import Plugin
+from nose.suite import ContextSuite
 
 from tap.tracker import Tracker
 
@@ -59,9 +60,14 @@ class TAP(Plugin):
         self.tracker.add_ok(self._cls_name(test), self._description(test))
 
     def _cls_name(self, test):
-        # nose masks the true test case name so the real class name is found
-        # under the test attribute.
-        return test.test.__class__.__name__
+        if isinstance(test, ContextSuite):
+            # In the class setup and teardown, test is a ContextSuite
+            # instead of a test case. Grab the name from the context.
+            return test.context.__name__
+        else:
+            # nose masks the true test case name so the real class name
+            # is found under the test attribute.
+            return test.test.__class__.__name__
 
     def _description(self, test):
         if self._format:

--- a/tap/tests/test_plugin.py
+++ b/tap/tests/test_plugin.py
@@ -9,8 +9,10 @@ except ImportError:
 # There is some weird conflict with `TestLoader.discover` if `nose.case.Test`
 # is imported directly. Importing `nose.case` works.
 from nose import case
+from nose.suite import ContextSuite
 
 from tap.plugin import TAP
+from tap.tests import TestCase
 
 
 class FakeOptions(object):
@@ -26,7 +28,7 @@ class FakeTestCase(object):
         pass
 
 
-class TestPlugin(unittest.TestCase):
+class TestPlugin(TestCase):
 
     @classmethod
     def _make_one(cls, options=None):
@@ -67,3 +69,18 @@ class TestPlugin(unittest.TestCase):
         plugin._description(test)
 
         self.assertTrue(fake_exit.called)
+
+    def test_get_name_from_context_suite(self):
+        """When the test is actually a ContextSuite, get the name from context.
+
+        setUpClass/tearDownClass provides a ContextSuite object to the plugin
+        if they raise an exception. The test case is not available so its
+        name must be pulled from a different location.
+        """
+        plugin = self._make_one()
+        context = mock.Mock(__name__='FakeContext')
+        test = ContextSuite(context=context)
+
+        name = plugin._cls_name(test)
+
+        self.assertEqual(name, 'FakeContext')


### PR DESCRIPTION
This prevents the `AttributeError` that occurs when there is an exception in `setUpClass`.

Fixes #11