### PR TITLE
runner.py/tracker.py: Add method to turn off header.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,4 +6,5 @@ Contributors
 * Chris Clarke
 * Matt Layman
 * Marc Abramowitz
+* Mark E. Hamilton
 * Nicolas Caniart

--- a/docs/producers.rst
+++ b/docs/producers.rst
@@ -146,6 +146,15 @@ methods.
 
       TAPTestRunner.set_format('{method_name}: {short_description}')
 
+* ``set_header`` - Turn off or on the test case header output. The default
+is True (ie, the header is displayed.)
+  Use the ``set_header`` instance method.
+
+  .. code-block:: python
+
+      runner = TAPTestRunner()
+      runner.set_header(False)
+
 nose TAP Plugin
 ---------------
 

--- a/tap/runner.py
+++ b/tap/runner.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) 2015, Matt Layman
 
 import os
@@ -125,6 +126,11 @@ class TAPTestRunner(TextTestRunner):
     def set_combined(cls, combined):
         """Set the tracker to use a single output file."""
         _tracker.combined = combined
+
+    @classmethod
+    def set_header(cls, header):
+        """Set the header display flag."""
+        _tracker.header = header
 
     @classmethod
     def set_format(cls, fmt):

--- a/tap/runner.py
+++ b/tap/runner.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, Matt Layman
 
 import os

--- a/tap/tests/test_runner.py
+++ b/tap/tests/test_runner.py
@@ -100,3 +100,17 @@ class TestTAPTestRunner(unittest.TestCase):
 
         _tracker.streaming = previous_streaming
         _tracker.stream = previous_stream
+
+    def test_runner_uses_header(self):
+        """Test that the case header can be turned off."""
+        # Save previous header in case **this** execution was using it.
+        previous_header = _tracker.header
+
+        TAPTestRunner.set_header(False)
+        self.assertFalse(_tracker.header)
+
+        TAPTestRunner.set_header(True)
+        self.assertTrue(_tracker.header)
+
+        _tracker.header = previous_header
+

--- a/tap/tests/test_runner.py
+++ b/tap/tests/test_runner.py
@@ -113,4 +113,3 @@ class TestTAPTestRunner(unittest.TestCase):
         self.assertTrue(_tracker.header)
 
         _tracker.header = previous_header
-

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -199,3 +199,22 @@ class TestTracker(TestCase):
             'FakeTestCase', 'a description', diagnostics='# more info\n')
         line = tracker._test_cases['FakeTestCase'][0]
         self.assertEqual('# more info\n', line.diagnostics)
+
+    def test_header_displayed_by_default(self):
+        tracker = Tracker()
+        self.assertTrue(tracker.header)
+
+    def test_header_set_by_init(self):
+        tracker = Tracker(header=False)
+        self.assertFalse(tracker.header)
+
+    def test_does_not_write_header(self):
+        stream = StringIO()
+        tracker = Tracker(streaming=True, stream=stream, header=False)
+
+        tracker.add_skip('FakeTestCase', 'YESSS!', 'a reason')
+
+        expected = inspect.cleandoc(
+            """ok 1 - YESSS! # SKIP a reason""")
+        self.assertEqual(stream.getvalue().strip(), expected)
+

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -217,4 +217,3 @@ class TestTracker(TestCase):
         expected = inspect.cleandoc(
             """ok 1 - YESSS! # SKIP a reason""")
         self.assertEqual(stream.getvalue().strip(), expected)
-

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2015, Matt Layman
 
 from __future__ import print_function
@@ -52,14 +51,6 @@ class Tracker(object):
             os.makedirs(outdir)
 
     outdir = property(_get_outdir, _set_outdir)
-
-    def _get_header(self):
-        return self._header
-
-    def _set_header(self, header):
-        self._header = header
-
-    header = property(_get_header, _set_header)
 
     def _track(self, class_name):
         """Keep track of which test cases have executed."""

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) 2015, Matt Layman
 
 from __future__ import print_function
@@ -13,7 +14,8 @@ from tap.line import Result
 class Tracker(object):
 
     def __init__(
-            self, outdir=None, combined=False, streaming=False, stream=None):
+            self, outdir=None, combined=False, streaming=False, stream=None,
+            header=True):
         self.outdir = outdir
 
         # Combine all the test results into one file.
@@ -28,6 +30,9 @@ class Tracker(object):
         # Stream output directly to a stream instead of file output.
         self.streaming = streaming
         self.stream = stream
+
+        # Display the test case header unless told not to.
+        self.header = header
 
         # Internal state for tracking each test case.
         self._test_cases = {}
@@ -48,10 +53,18 @@ class Tracker(object):
 
     outdir = property(_get_outdir, _set_outdir)
 
+    def _get_header(self):
+        return self._header
+
+    def _set_header(self, header):
+        self._header = header
+
+    header = property(_get_header, _set_header)
+
     def _track(self, class_name):
         """Keep track of which test cases have executed."""
         if self._test_cases.get(class_name) is None:
-            if self.streaming:
+            if self.streaming and self.header:
                 self._write_test_case_header(class_name, self.stream)
 
             self._test_cases[class_name] = []


### PR DESCRIPTION
It seems logical to have method to turn off the test case header output for users (like us) who don't want to see it. This commit adds an additional optional parameter to the Tracker class to do so. The default remains as True; the set_header method will allow for turning it on or off.

This commit adds a method to the header class to turn this flag on/off in the embedded _tracker object.

This class also adds tests for these new features (though it took some  work to get the tests to run. ;) )
