### PR TITLE
Remove Babel hard dependency in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,5 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate; fi
 install:
-  - pip install tox
+  - pip install Babel tox
 script: tox -e $TOX_ENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PATH: "C:\\Python34;C:\\Python34\\Scripts;%PATH%"
 install:
     - python -m ensurepip
-    - pip install tox
+    - pip install Babel tox
 build_script:
     - python --version
 test_script:

--- a/setup.py
+++ b/setup.py
@@ -79,9 +79,6 @@ if __name__ == '__main__':
         zip_safe=False,
         platforms='any',
         install_requires=install_requirements(),
-        setup_requires=[
-            'Babel',  # sdist compiles po into mo.
-        ],
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Console',

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,15 @@ deps =
 commands = nosetests --with-tap
 
 [testenv:runner]
-deps = mock
+deps =
+    Babel
+    mock
 commands = python tap/tests/run.py
 
 [testenv:flake8]
-deps = flake8
+deps =
+    Babel
+    flake8
 commands = flake8 tap setup.py transifex.py
 
 [testenv:integration]
@@ -44,6 +48,7 @@ setenv =
     CI = true
 passenv = TRAVIS*
 deps =
+    Babel
     coverage
     mock
     codecov

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,10 @@ envlist = py26
           language_zh
 
 [testenv]
-deps = mock
-       nose
+deps =
+    Babel
+    mock
+    nose
 commands = nosetests --with-tap
 
 [testenv:runner]


### PR DESCRIPTION
Babel is only needed as a tool to build the distribution. That can be done in a separate packaging step.

Fixes #46